### PR TITLE
Specify file(s)/folder(s)/filename extension with command line arguments

### DIFF
--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -84,14 +84,12 @@ def md2nb(file_path, extension='.md'):
     return
 
 
-def md2nb_all(directory='.', extension='.md'):
+def md2nb_all(directory='.', extension='.md', recursive=False):
     if directory[-1] == '/' and len(directory) > 1:
         directory = directory[:-1]
 
-    file_paths = [
-        file_path for file_path
-        in glob.glob(f"{directory}/*{extension}")
-    ]
+    file_paths = glob.glob(f"{directory}/**/*{extension}",
+                           recursive=True) if recursive else glob.glob(f"{directory}/*{extension}")
     print(f"Converting '{extension}' files within {directory}/:")
     print('\t' + '\n\t'.join(file_paths))
     for file_path in file_paths:
@@ -108,6 +106,8 @@ def main():
     # TODO: Allow more than one extension
     parser.add_argument(
         "--ext", default='.md', help="target only files with this filename extension", dest="extension")
+    parser.add_argument("-r", "--recursive", action='store_true',
+                        help="recursively apply `md2nb` to all subdirectories")
     args = parser.parse_args()
 
     if len(sys.argv) == 1:
@@ -121,7 +121,8 @@ def main():
 
     if args.dir:
         for dir_path in args.dir:
-            md2nb_all(directory=dir_path, extension=args.extension)
+            md2nb_all(directory=dir_path,
+                      extension=args.extension, recursive=args.recursive)
 
 
 if __name__ == '__main__':

--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import glob
 import json
@@ -38,6 +39,22 @@ template = '''{
  "nbformat": 4,
  "nbformat_minor": 4
 }'''
+
+
+def is_file(string):
+    if not os.path.isfile(string):
+        msg = "%r is not a valid file path" % string
+        raise argparse.ArgumentTypeError(msg)
+    else:
+        return string
+
+
+def is_dir(string):
+    if not os.path.isdir(string):
+        msg = "%r is not a valid directory path" % string
+        raise argparse.ArgumentTypeError(msg)
+    else:
+        return string
 
 
 def detect_encoding(file_path):
@@ -84,27 +101,27 @@ def md2nb_all(directory='.', extension='.md'):
 
 def main():
     parser = argparse.ArgumentParser()
-    # TODO: Check these are actual file paths
-    parser.add_argument("filenames", help="files to be converted", nargs='*')
-    # TODO: Check these are actual directory paths
-    # TODO: Allow more than one directory
     parser.add_argument(
-        "--dir", help="directory containing the Markdown files")
+        "filenames", nargs='*', type=is_file, help="files to be converted")
     parser.add_argument(
-        "--ext", help="target only files with this filename extension", dest="extension", default='.md')
+        "--dir", nargs='+', type=is_dir, help="directory containing the Markdown files")
+    # TODO: Allow more than one extension
+    parser.add_argument(
+        "--ext", default='.md', help="target only files with this filename extension", dest="extension")
     args = parser.parse_args()
 
     if len(sys.argv) == 1:
         parser.print_help()
 
     if args.filenames:
-        print(f"Converting the following files:")
+        print(f"Converting the following user-specified files:")
         print('\t' + '\n\t'.join(args.filenames))
         for file_path in args.filenames:
             md2nb(file_path)
 
     if args.dir:
-        md2nb_all(directory=args.dir, extension=args.extension)
+        for dir_path in args.dir:
+            md2nb_all(directory=dir_path, extension=args.extension)
 
 
 if __name__ == '__main__':

--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -1,5 +1,7 @@
+import sys
 import glob
 import json
+import argparse
 from chardet.universaldetector import UniversalDetector
 
 __copyright__ = "Copyright 2020, Qin Yu"
@@ -65,13 +67,45 @@ def md2nb(file_path, extension='.md'):
     return
 
 
-def md2nb_all(extension='.md'):
-    file_paths = [file_path for file_path in glob.glob(f"*{extension}")]
-    print(f"The following files are about to be converted: {file_paths}")
+def md2nb_all(directory='.', extension='.md'):
+    if directory[-1] == '/' and len(directory) > 1:
+        directory = directory[:-1]
+
+    file_paths = [
+        file_path for file_path
+        in glob.glob(f"{directory}/*{extension}")
+    ]
+    print(f"Converting '{extension}' files within {directory}/:")
+    print('\t' + '\n\t'.join(file_paths))
     for file_path in file_paths:
         md2nb(file_path, extension=extension)
     return
 
 
+def main():
+    parser = argparse.ArgumentParser()
+    # TODO: Check these are actual file paths
+    parser.add_argument("filenames", help="files to be converted", nargs='*')
+    # TODO: Check these are actual directory paths
+    # TODO: Allow more than one directory
+    parser.add_argument(
+        "--dir", help="directory containing the Markdown files")
+    parser.add_argument(
+        "--ext", help="target only files with this filename extension", dest="extension", default='.md')
+    args = parser.parse_args()
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+
+    if args.filenames:
+        print(f"Converting the following files:")
+        print('\t' + '\n\t'.join(args.filenames))
+        for file_path in args.filenames:
+            md2nb(file_path)
+
+    if args.dir:
+        md2nb_all(directory=args.dir, extension=args.extension)
+
+
 if __name__ == '__main__':
-    md2nb_all()
+    main()

--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -100,12 +100,11 @@ def md2nb_all(directory='.', extension='.md', recursive=False):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "filenames", nargs='*', type=is_file, help="files to be converted")
+        "filenames", nargs='*', type=is_file, help="paths for files to be converted")
     parser.add_argument(
         "--dir", nargs='+', type=is_dir, help="directory containing the Markdown files")
-    # TODO: Allow more than one extension
     parser.add_argument(
-        "--ext", default='.md', help="target only files with this filename extension", dest="extension")
+        "--ext", nargs='+', default=['.md'], help="target only files ending with these", dest="extension")
     parser.add_argument("-r", "--recursive", action='store_true',
                         help="recursively apply `md2nb` to all subdirectories")
     args = parser.parse_args()
@@ -116,13 +115,14 @@ def main():
     if args.filenames:
         print(f"Converting the following user-specified files:")
         print('\t' + '\n\t'.join(args.filenames))
-        for file_path in args.filenames:
+        for file_path in set(args.filenames):
             md2nb(file_path)
 
     if args.dir:
-        for dir_path in args.dir:
-            md2nb_all(directory=dir_path,
-                      extension=args.extension, recursive=args.recursive)
+        for dir_path in set(args.dir):
+            for file_ext in set(args.extension):
+                md2nb_all(directory=dir_path,
+                          extension=file_ext, recursive=args.recursive)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="md2nb",  # Replace with your own username
-    version="0.0.2",
+    version="0.1.0",
     author="Qin Yu",
     author_email="qin.yu@embl.de",
     license="bsd-3-clause",
@@ -26,7 +26,7 @@ setuptools.setup(
     python_requires='>=3.6',
     entry_points={
         'console_scripts': [
-            'md2nb=md2nb.md2nb:md2nb_all',
+            'md2nb=md2nb.md2nb:main',
         ],
     },
 )


### PR DESCRIPTION
This PR attempts to fix https://github.com/qin-yu/md2nb/issues/2

I eventually decided to do it this way:
- for files, pass 0 to n filenames as a positional argument: one can even use this to specify filename extensions!
- for folders, pass 1 to n directory paths as an optional argument `--dir` 
    - was thinking of `-r` but maybe save it for `--recursive`?
    - `--ext` for the filename extension to use in the directories
- if none specified, ~throw exception~ show help
- if both specified, convert both