### PR TITLE
Add duplicate warning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,5 @@
             "# `md2nb` - Converting Markdown Files to Jupyter Notebook",
             "# Table of Contents"
         ]
-    },
-    "python.pythonPath": "/Users/voidvalley/miniconda3/envs/learn/bin/python"
+    }
 }

--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -164,7 +164,8 @@ def main():
 
     print(file_duplicate)
     if file_duplicate != []:
-        print(f"The following files are specified twice: {file_duplicate}")
+        print(
+            f"The following files are specified more than once: {file_duplicate}")
 
 
 if __name__ == '__main__':

--- a/md2nb/md2nb.py
+++ b/md2nb/md2nb.py
@@ -10,35 +10,38 @@ __author__ = "Qin Yu"
 __email__ = "qin.yu@embl.de"
 
 template = '''{
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source":
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.8"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source":
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.7.8"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
 }'''
+
+file_converted = []
+file_duplicate = []
 
 
 def is_file(string):
@@ -77,11 +80,18 @@ def md2nb(file_path, extension=None, dry=False):
     # `str()` prints strings with single quotes, while `json.dumps()` prints with double quotes.
     with open(file_path, 'r', encoding=detect_encoding(file_path)) as f_md:
         t_md = f_md.readlines()
-    t_nb = template[:78] + json.dumps(t_md) + template[78:]
+    t_nb = template[:113] + json.dumps(t_md) + template[113:]
     t_nb = json.loads(t_nb)  # 'load string'
 
     file_out_path = file_path + \
         '.ipynb' if extension == '' else file_path[:-len(extension)] + '.ipynb'
+
+    file_abs_path = os.path.abspath(file_path)
+    if file_abs_path in file_converted:
+        file_duplicate.append(file_abs_path)
+        return
+    else:
+        file_converted.append(file_abs_path)
     if not dry:
         with open(file_out_path, 'w') as f_nb:
             # Making JSON human readable (aka "pretty printing") is as easy as passing an integer value for the indent parameter
@@ -151,6 +161,10 @@ def main():
             for file_ext in set(args.extension):
                 md2nb_all(directory=dir_path,
                           extension=file_ext, recursive=args.recursive, dry=args.dry_run)
+
+    print(file_duplicate)
+    if file_duplicate != []:
+        print(f"The following files are specified twice: {file_duplicate}")
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="md2nb",  # Replace with your own username
-    version="0.2.1",
+    version="0.2.2",
     author="Qin Yu",
     author_email="qin.yu@embl.de",
     license="bsd-3-clause",


### PR DESCRIPTION
This PR tries to fix #10 

When a file has been converted, it is still evaluated because the conversion is cheap, but it is not written to that output file again. The user is warned that the file has been specified more than once.